### PR TITLE
Update Coqui to 0.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 faster_whisper==1.0.2
 gradio==4.13.0
 spacy==3.7.4
-coqui-tts[languages] == 0.24.1
+coqui-tts[languages] == 0.24.2
 
 cutlet
 fugashi[unidic-lite]


### PR DESCRIPTION
0.24.2 mostly contains a lot of bug fixes since the last release, see the full list here: https://github.com/idiap/coqui-ai-TTS/releases/tag/v0.24.2

Otherwise the most useful things for this repo are:
- Hindi support in the XTTS tokenizer, so fine-tuning and synthesising Hindi is fully supported now
- I now also make prebuilt wheels for Mac and Windows available on PyPI, so users don't need to install the C++ build tools anymore on Windows. Fixes #52

The same change should probably also be made in https://github.com/daswer123/xtts-webui