### PR TITLE
Update title docker features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim-bookworm AS base
+
+ARG APP_NAME=xtts-finetune-webui
+ARG CUDA_VER=cu121
+ARG GID=966
+ARG UID=966
+ARG WHISPER_MODEL="large-v3"
+
+# Environment
+ENV APP_NAME=$APP_NAME \
+    CUDA_VER=$CUDA_VER \
+    WHISPER_MODEL=$WHISPER_MODEL
+
+# User configuration
+ENV HOME /app/$APP_NAME
+RUN groupadd -r app -g $GID && \
+    useradd --no-log-init -m -r -g app app -u $UID
+
+# Prepare file-system
+RUN mkdir -p /app/server && chown -R $UID:$GID /app
+COPY --chown=$UID:$GID *.py *.sh *.txt *.md /app/server/
+ADD --chown=$UID:$GID utils /app/server/utils
+
+# Enter environment and install dependencies
+WORKDIR /app/server
+
+USER $UID:$GID
+
+ENV NVIDIA_VISIBLE_DEVICES=all PATH=$PATH:$HOME/.local/bin
+# Install nvidia-pyindex & nvidia-cudnn for libcudnn_ops_infer.so.8
+# See: https://github.com/SYSTRAN/faster-whisper/issues/516
+RUN pip3 install --user --no-cache-dir nvidia-pyindex && \
+    pip3 install --user --no-cache-dir nvidia-cudnn && \
+    pip3 install --user --no-cache-dir torch torchvision torchaudio \
+        --index-url https://download.pytorch.org/whl/$CUDA_VER && \
+    pip3 install --user --no-cache-dir -r requirements.txt --no-cache-dir && \
+    python3 -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8')"
+
+# Ports and servername
+EXPOSE 5003
+ENV GRADIO_ANALYTICS_ENABLED="False"
+
+CMD [ "bash", "start-container.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-faster_whisper==1.0.2
-gradio==4.13.0
-spacy==3.7.4
+faster_whisper==1.0.3
+gradio==5.1.0
+spacy==3.7.5
 coqui-tts[languages] == 0.24.2
 
 cutlet

--- a/start-container.sh
+++ b/start-container.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Enable resolution of libcudnn_ops_infer.so.8
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/app/xtts-finetune-webui/.local/lib/python3.11/site-packages/torch/lib:/app/xtts-finetune-webui/.local/lib/python3.11/site-packages/nvidia/cudnn/lib"
+
+python3 xtts_demo.py

--- a/xtts_demo.py
+++ b/xtts_demo.py
@@ -22,9 +22,6 @@ from faster_whisper import WhisperModel
 from TTS.tts.configs.xtts_config import XttsConfig
 from TTS.tts.models.xtts import Xtts
 
-from TTS.tts.configs.xtts_config import XttsConfig
-from TTS.tts.models.xtts import Xtts
-
 import requests
 
 def download_file(url, destination):

--- a/xtts_demo.py
+++ b/xtts_demo.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    with gr.Blocks() as demo:
+    with gr.Blocks(title=os.environ.get("APP_NAME", "Gradio")) as demo:
         with gr.Tab("1 - Data processing"):
             out_path = gr.Textbox(
                 label="Output path (where data and checkpoints will be saved):",


### PR DESCRIPTION
Thanks for your work!

This PR makes the following changes:

1. Remove duplicate imports for TTS module
2. Add Dockerfile & accompanying start-container.sh    
    The supported build arguments (and defaults) are:
    
    ```
    APP_NAME=xtts-finetune-webui
    CUDA_VER=cu121
    GID=966
    UID=966
    WHISPER_MODEL="large-v3"
    ```
3. Update whisper, gradio, and spacy deps. Add title.
    Update dependencies to support latest combination of dependency chain. See [this Gradio issue](https://github.com/gradio-app/gradio/issues/9278 "Gradio Issue #9278"). Add env var `APP_NAME` to set the Gradio app title.